### PR TITLE
Use boost regex instead of std, because of buggy glibc++ in RHEL7

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ else()
 endif()
 
 #Only tested with versions 1.55 and 1.56
-find_package(Boost 1.54.0 COMPONENTS system thread coroutine context filesystem REQUIRED)
+find_package(Boost 1.54.0 COMPONENTS regex system thread coroutine context filesystem REQUIRED)
 message("Boost include dir: ${Boost_INCLUDE_DIR}")
 message("Boost libraries: ${Boost_LIBRARIES}")
 include_directories(${Boost_INCLUDE_DIR})

--- a/server_http.hpp
+++ b/server_http.hpp
@@ -3,8 +3,8 @@
 
 #include <boost/asio.hpp>
 #include <boost/asio/spawn.hpp>
+#include <boost/regex.hpp>
 
-#include <regex>
 #include <unordered_map>
 #include <thread>
 #include <functional>
@@ -65,7 +65,7 @@ namespace SimpleWeb {
 
             std::unordered_multimap<std::string, std::string> header;
 
-            std::smatch path_match;
+            boost::smatch path_match;
             
             std::string remote_endpoint_address;
             unsigned short remote_endpoint_port;
@@ -93,7 +93,7 @@ namespace SimpleWeb {
             std::function<void(typename ServerBase<socket_type>::Response&, std::shared_ptr<typename ServerBase<socket_type>::Request>)> > default_resource;
 
     private:
-        std::vector<std::pair<std::string, std::vector<std::pair<std::regex, 
+        std::vector<std::pair<std::string, std::vector<std::pair<boost::regex,
             std::function<void(typename ServerBase<socket_type>::Response&, std::shared_ptr<typename ServerBase<socket_type>::Request>)> > > > > opt_resource;
         
     public:
@@ -114,7 +114,7 @@ namespace SimpleWeb {
                         it=opt_resource.begin()+(opt_resource.size()-1);
                         it->first=res_method.first;
                     }
-                    it->second.emplace_back(std::regex(res.first), res_method.second);
+                    it->second.emplace_back(boost::regex(res.first), res_method.second);
                 }
             }
                         
@@ -269,8 +269,8 @@ namespace SimpleWeb {
             for(auto& res: opt_resource) {
                 if(request->method==res.first) {
                     for(auto& res_path: res.second) {
-                        std::smatch sm_res;
-                        if(std::regex_match(request->path, sm_res, res_path.first)) {
+                        boost::smatch sm_res;
+                        if(boost::regex_match(request->path, sm_res, res_path.first)) {
                             request->path_match=std::move(sm_res);
                             write_response(socket, request, res_path.second);
                             return;


### PR DESCRIPTION
On Red Hat Enterprise Linux 7 / CentOS 7, Simple-Web-Server does not work because of buggy regex implementation in libstdc++. This patch fixes the issue by using boost's regex implementation.