### PR TITLE
Add install target for headers in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,4 +51,4 @@ endif()
 enable_testing()
 add_subdirectory(tests)
 
-install(FILES server_http.hpp client_http.hpp server_https.hpp client_https.hpp DESTINATION include/simplewebserver)
+install(FILES server_http.hpp client_http.hpp server_https.hpp client_https.hpp DESTINATION include/simple-web-server)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,3 +50,5 @@ endif()
 
 enable_testing()
 add_subdirectory(tests)
+
+install(FILES server_http.hpp client_http.hpp server_https.hpp client_https.hpp DESTINATION include/simplewebserver)


### PR DESCRIPTION
For those of us using automated build systems, allowing cmake to generate an install target for headers (via make install) makes things a lot cleaner.