### PR TITLE
Fixing response header

### DIFF
--- a/http_examples.cpp
+++ b/http_examples.cpp
@@ -60,8 +60,8 @@ int main() {
             *response << "HTTP/1.1 200 OK" << "\r\n"
                       << "Access-Control-Allow-Origin: *" << "\r\n" 
                       << "Content-Type: application/json" << "\r\n" 
-                      <<"Content-Length: " << name.length() << "\r\n"
-                      <<"\r\n"
+                      << "Content-Length: " << name.length() << "\r\n"
+                      << "\r\n"
                       << name;
         }
         catch(exception& e) {

--- a/http_examples.cpp
+++ b/http_examples.cpp
@@ -57,9 +57,11 @@ int main() {
 
             string name=pt.get<string>("firstName")+" "+pt.get<string>("lastName");
 
-            *response << "Access-Control-Allow-Origin: *" << "\r\n" 
+            *response << "HTTP/1.1 200 OK" << "\r\n"
+                      << "Access-Control-Allow-Origin: *" << "\r\n" 
                       << "Content-Type: application/json" << "\r\n" 
-                      << "HTTP/1.1 200 OK\r\nContent-Length: " << name.length() << "\r\n\r\n"
+                      <<"Content-Length: " << name.length() << "\r\n"
+                      <<"\r\n"
                       << name;
         }
         catch(exception& e) {

--- a/http_examples.cpp
+++ b/http_examples.cpp
@@ -57,13 +57,16 @@ int main() {
 
             string name=pt.get<string>("firstName")+" "+pt.get<string>("lastName");
 
-            *response << "HTTP/1.1 200 OK\r\nContent-Length: " << name.length() << "\r\n\r\n" << name;
+            *response << "HTTP/1.1 200 OK\r\nContent-Length: " << name.length() << "\r\n" 
+                      << "Access-Control-Allow-Origin: *" << "\r\n" 
+                      << "Content-Type: application/json" << "\r\n\r\n" 
+                      << name;
         }
         catch(exception& e) {
             *response << "HTTP/1.1 400 Bad Request\r\nContent-Length: " << strlen(e.what()) << "\r\n\r\n" << e.what();
         }
     };
-    
+
     //GET-example for the path /info
     //Responds with request-information
     server.resource["^/info$"]["GET"]=[](shared_ptr<HttpServer::Response> response, shared_ptr<HttpServer::Request> request) {

--- a/http_examples.cpp
+++ b/http_examples.cpp
@@ -57,9 +57,9 @@ int main() {
 
             string name=pt.get<string>("firstName")+" "+pt.get<string>("lastName");
 
-            *response << "HTTP/1.1 200 OK\r\nContent-Length: " << name.length() << "\r\n" 
-                      << "Access-Control-Allow-Origin: *" << "\r\n" 
-                      << "Content-Type: application/json" << "\r\n\r\n" 
+            *response << "Access-Control-Allow-Origin: *" << "\r\n" 
+                      << "Content-Type: application/json" << "\r\n" 
+                      << "HTTP/1.1 200 OK\r\nContent-Length: " << name.length() << "\r\n\r\n"
                       << name;
         }
         catch(exception& e) {


### PR DESCRIPTION
Previously, running 

$.post( "json", JSON.stringify({ firstName: "John", lastName: "Smith", age: 25 }) );

would give an error message in Firefox browser console
syntax error

Now, this error message is not shown.