### PR TITLE
support for meson build system

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,12 +30,21 @@ See particularly the JSON-POST (using Boost.PropertyTree) and the GET /match/[nu
 ### Compile and run
 
 Compile with a C++11 compliant compiler:
+
+#### Cmake
 ```sh
 mkdir build
 cd build
 cmake ..
-make
-cd ..
+```
+
+#### Meson
+
+```
+mkdir build
+cd build
+meson
+ninja
 ```
 
 #### HTTP
@@ -52,3 +61,27 @@ Run the server and client examples: `./build/https_examples`
 
 Direct your favorite browser to for instance https://localhost:8080/
 
+### Using Simple-Web-Server As a Messon Subproject
+
+for more information regarding meson subprojects see: https://github.com/mesonbuild/meson/wiki/Subprojects
+
+Create a file `/path/to/yourproject/subprojects/simple-web-server.wrap`
+which contains
+```
+[wrap-git]
+directory = simple-web-server
+url = https://github.com/eidheim/Simple-Web-Server.git
+revision = head
+```
+
+In your projects top most meson.build file add
+```
+# load the simple web server as a subproject
+sws_sp = subproject('simple-web-server')
+
+# get include files, add this to the include list of targets that use Simple Web Server
+sws_inc = simple_web_server_sp.get_variable('inc')
+
+# get dependency list, ass this to the dependency list of targets that use Simple Web Server
+sws_deps = simple_web_server_sp.get_variable('deps')
+```

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,45 @@
+project('Simple-Web-Server', 'cpp', license : 'MIT')
+
+compiler_args = ['-std=c++11', '-Wall', '-Wextra']
+
+compiler_info = meson.get_compiler('cpp')
+if compiler_info.get_id() == 'gcc'
+    if compiler_info.version().version_compare('<4.8')
+        error('GCC version >=4.8 required. Found version ' + compiler_info.version())
+    endif
+elif compiler_info.get_id() == 'clang'
+     if compiler_info.version().version_compare('<3.3')
+        error('Clang version >=3.3 required. Found version ' + compiler_info.version())
+    endif
+else
+    message('Your compiler has not been tested on this project. Only Clang and GCC has been tested. Please report any
+    problems at the project page on GitHub.')
+endif
+
+inc = include_directories(meson.current_source_dir())
+
+threads_dep = dependency('threads')
+boost_dep = dependency('boost', modules : ['thread', 'utility', 'system', 'filesystem', 'regex'])
+
+deps = [threads_dep, boost_dep]
+
+# how do we define SSL support on Mac systems?
+#if 'APPLE'
+  #openssl_root_dir = '/usr/local/opt/openssl'
+#endif
+
+#TODO: add requirement for version 1.0.1g (can it be done in one line?)
+openssl_dep = dependency('openssl', required : false)
+
+if openssl_dep.found()
+    deps += openssl_dep
+    https_examples_exe = executable('https_examples', 'https_examples.cpp', dependencies : [openssl_dep, threads_dep, boost_dep], cpp_args : compiler_args)
+else
+    message('Warning: OpenSSL not found on your system. https examples will not be compiled')
+endif
+
+http_examples_exe = executable('http_examples', 'http_examples.cpp', dependencies : [threads_dep, boost_dep], cpp_args : compiler_args)
+
+subdir('tests')
+
+install_headers(['client_http.hpp', 'client_https.hpp', 'server_http.hpp', 'server_https.hpp'])

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1,0 +1,12 @@
+
+test_cpp_args = []
+test_cpp_args += compiler_args
+test_cpp_args += ['-fno-access-control']
+
+io_test_exe = executable('io_test', 'io_test.cpp',  cpp_args : test_cpp_args, include_directories : inc, dependencies : [threads_dep, boost_dep])
+
+parse_test_exe = executable('parse_test', 'parse_test.cpp',  cpp_args : test_cpp_args, include_directories : inc, dependencies : [threads_dep, boost_dep])
+
+test('io_test', io_test_exe)
+
+test('parse_test', parse_test_exe)


### PR DESCRIPTION
http://mesonbuild.com/

The Meson build system allows to easily define third party dependencies.
This pull request enables meson projects to easily use Simple-Web-Server as a dependency.
(Tested on Linux)