### PR TITLE
Added support for HTTP caching in the https example

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,7 @@ target_link_libraries(http_examples ${CMAKE_THREAD_LIBS_INIT})
 find_package(OpenSSL)
 
 if(OPENSSL_FOUND)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DHAVE_OPENSSL")
     include_directories(SYSTEM ${OPENSSL_INCLUDE_DIR})
 
     add_executable(https_examples https_examples.cpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,7 @@ find_package(OpenSSL)
 
 if(OPENSSL_FOUND)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DHAVE_OPENSSL")
+    target_link_libraries(http_examples ${OPENSSL_LIBRARIES})
     include_directories(SYSTEM ${OPENSSL_INCLUDE_DIR})
 
     add_executable(https_examples https_examples.cpp)

--- a/http_examples.cpp
+++ b/http_examples.cpp
@@ -147,7 +147,7 @@ int main() {
                 
                 ifs->seekg(0, ios::beg);
                 
-                *response << "HTTP/1.1 200 OK\r\nContent-Length: " << length << "\r\n\r\n";
+                *response << "HTTP/1.1 200 OK\r\n" << cache_ctrl << "Content-Length: " << length << "\r\n\r\n";
                 default_resource_send(server, response, ifs);
             }
             else

--- a/http_examples.cpp
+++ b/http_examples.cpp
@@ -1,5 +1,8 @@
 #include "server_http.hpp"
 #include "client_http.hpp"
+#ifdef HAVE_OPENSSL
+#include "crypto.hpp"
+#endif
 
 //Added for the json-example
 #define BOOST_SPIRIT_THREADSAFE
@@ -18,6 +21,10 @@ using namespace boost::property_tree;
 
 typedef SimpleWeb::Server<SimpleWeb::HTTP> HttpServer;
 typedef SimpleWeb::Client<SimpleWeb::HTTP> HttpClient;
+
+#ifdef HAVE_OPENSSL
+std::string build_hash(const std::string full_file_name);
+#endif
 
 //Added for the default_resource example
 void default_resource_send(const HttpServer &server, const shared_ptr<HttpServer::Response> &response,
@@ -108,6 +115,7 @@ int main() {
         try {
             auto web_root_path=boost::filesystem::canonical("web");
             auto path=boost::filesystem::canonical(web_root_path/request->path);
+	    std::string cache_ctrl = "";
             //Check if path is within web_root_path
             if(distance(web_root_path.begin(), web_root_path.end())>distance(path.begin(), path.end()) ||
                !equal(web_root_path.begin(), web_root_path.end(), path.begin()))
@@ -117,6 +125,19 @@ int main() {
             if(!(boost::filesystem::exists(path) && boost::filesystem::is_regular_file(path)))
                 throw invalid_argument("file does not exist");
             
+#ifdef HAVE_OPENSSL
+	    //Support for HTTP Cache
+	    std::string hash = build_hash(path.string());
+	    auto it=request->header.find("If-None-Match");
+	    if(it!=request->header.end()) {
+		if (it->second == "\""+hash+"\"") {
+		    *response << "HTTP/1.1 304 Not Modified\r\nCache-Control: max-age=86400\r\nETag: \""+hash+"\"\r\n\r\n";
+		    return;
+		}
+	    }
+	    cache_ctrl = "Cache-Control: max-age=86400\r\nETag: \""+hash+"\"\r\n";
+#endif
+
             auto ifs=make_shared<ifstream>();
             ifs->open(path.string(), ifstream::in | ios::binary);
             
@@ -180,3 +201,17 @@ void default_resource_send(const HttpServer &server, const shared_ptr<HttpServer
         }
     }
 }
+
+#ifdef HAVE_OPENSSL
+std::string build_hash(const std::string full_file_name) {
+    std::string ret = "";
+    std::ifstream file(full_file_name, std::ios::binary | std::ios::ate);
+    std::streamsize size = file.tellg();
+    file.seekg(0, std::ios::beg);
+    std::vector<char> buffer(size);
+    if (!file.read(buffer.data(), size))
+        return ret;
+    ret = reinterpret_cast<char*> (&buffer[0]);
+    return SimpleWeb::Crypto::md5(ret,1);
+}
+#endif

--- a/https_examples.cpp
+++ b/https_examples.cpp
@@ -1,6 +1,8 @@
 #include "server_https.hpp"
 #include "client_https.hpp"
+#ifdef HAVE_OPENSSL
 #include "crypto.hpp"
+#endif
 
 //Added for the json-example
 #define BOOST_SPIRIT_THREADSAFE
@@ -23,7 +25,9 @@ typedef SimpleWeb::Client<SimpleWeb::HTTPS> HttpsClient;
 //Added for the default_resource example
 void default_resource_send(const HttpsServer &server, const shared_ptr<HttpsServer::Response> &response,
                            const shared_ptr<ifstream> &ifs);
+#ifdef HAVE_OPENSSL
 std::string build_hash(const std::string full_file_name);
+#endif
 int main() {
     //HTTPS-server at port 8080 using 1 thread
     //Unless you do more heavy non-threaded processing in the resources,
@@ -109,6 +113,7 @@ int main() {
         try {
             auto web_root_path=boost::filesystem::canonical("web");
             auto path=boost::filesystem::canonical(web_root_path/request->path);
+	    std::string cache_ctrl = "";
             //Check if path is within web_root_path
             if(distance(web_root_path.begin(), web_root_path.end())>distance(path.begin(), path.end()) ||
                !equal(web_root_path.begin(), web_root_path.end(), path.begin()))
@@ -118,6 +123,7 @@ int main() {
             if(!(boost::filesystem::exists(path) && boost::filesystem::is_regular_file(path)))
                 throw invalid_argument("file does not exist");
 
+#ifdef HAVE_OPENSSL
 	    //Support for HTTP Cache
 	    std::string hash = build_hash(path.string());
 	    auto it=request->header.find("If-None-Match");
@@ -127,6 +133,8 @@ int main() {
 		    return;
 		}
 	    }
+	    cache_ctrl = "Cache-Control: max-age=86400\r\nETag: \""+hash+"\"\r\n";
+#endif
 
             auto ifs=make_shared<ifstream>();
             ifs->open(path.string(), ifstream::in | ios::binary);
@@ -137,7 +145,7 @@ int main() {
                 
                 ifs->seekg(0, ios::beg);
                 
-                *response << "HTTP/1.1 200 OK\r\nCache-Control: max-age=86400\r\nETag: \""+hash+"\"\r\nContent-Length: " << length << "\r\n\r\n";
+                *response << "HTTP/1.1 200 OK\r\n" << cache_ctrl << "Content-Length: " << length << "\r\n\r\n";
                 default_resource_send(server, response, ifs);
             }
             else
@@ -193,6 +201,7 @@ void default_resource_send(const HttpsServer &server, const shared_ptr<HttpsServ
     }
 }
 
+#ifdef HAVE_OPENSSL
 std::string build_hash(const std::string full_file_name) {
     std::string ret = "";
     std::ifstream file(full_file_name, std::ios::binary | std::ios::ate);
@@ -204,3 +213,4 @@ std::string build_hash(const std::string full_file_name) {
     ret = reinterpret_cast<char*> (&buffer[0]);
     return SimpleWeb::Crypto::md5(ret,1);
 }
+#endif


### PR DESCRIPTION
Takes number 2.
Using your crypto namespace md5 function this time.