### PR TITLE
removing explicit reference to std::regex

### DIFF
--- a/server_http.hpp
+++ b/server_http.hpp
@@ -21,6 +21,26 @@
 #endif
 
 namespace SimpleWeb {
+    class RequestBase {
+    public:
+            //Based on http://www.boost.org/doc/libs/1_60_0/doc/html/unordered/hash_equality.html
+            class iequal_to {
+            public:
+              bool operator()(const std::string &key1, const std::string &key2) const {
+                return boost::algorithm::iequals(key1, key2);
+              }
+            };
+            class ihash {
+            public:
+              size_t operator()(const std::string &key) const {
+                std::size_t seed=0;
+                for(auto &c: key)
+                  boost::hash_combine(seed, std::tolower(c));
+                return seed;
+              }
+            };
+    };
+
     template <class socket_type>
     class Server;
     
@@ -60,26 +80,10 @@ namespace SimpleWeb {
             Content(boost::asio::streambuf &streambuf): std::istream(&streambuf), streambuf(streambuf) {}
         };
         
-        class Request {
+        class Request: public RequestBase {
             friend class ServerBase<socket_type>;
             friend class Server<socket_type>;
             
-            //Based on http://www.boost.org/doc/libs/1_60_0/doc/html/unordered/hash_equality.html
-            class iequal_to {
-            public:
-              bool operator()(const std::string &key1, const std::string &key2) const {
-                return boost::algorithm::iequals(key1, key2);
-              }
-            };
-            class ihash {
-            public:
-              size_t operator()(const std::string &key) const {
-                std::size_t seed=0;
-                for(auto &c: key)
-                  boost::hash_combine(seed, std::tolower(c));
-                return seed;
-              }
-            };
         public:
             std::string method, path, http_version;
 


### PR DESCRIPTION
Compile failed on old compilers due to explicit reference to std::regex.

My fork also has a change to move the hash function out of the templated class.  If this is not desirable, please just fix REGEX_NS and disregard this PR.