### PR TITLE
added Support for NO_BOOST

### DIFF
--- a/client_https.hpp
+++ b/client_https.hpp
@@ -5,7 +5,7 @@
 #include <boost/asio/ssl.hpp>
 
 namespace SimpleWeb {
-    typedef boost::asio::ssl::stream<boost::asio::ip::tcp::socket> HTTPS;
+    typedef asio_ns::ssl::stream<asio_ns::ip::tcp::socket> HTTPS;
     
     template<>
     class Client<HTTPS> : public ClientBase<HTTPS> {
@@ -13,14 +13,14 @@ namespace SimpleWeb {
         Client(const std::string& server_port_path, bool verify_certificate=true, 
                 const std::string& cert_file=std::string(), const std::string& private_key_file=std::string(), 
                 const std::string& verify_file=std::string()) : 
-                ClientBase<HTTPS>::ClientBase(server_port_path, 443), context(boost::asio::ssl::context::tlsv12) {
+                ClientBase<HTTPS>::ClientBase(server_port_path, 443), context(asio_ns::ssl::context::tlsv12) {
             if(cert_file.size()>0 && private_key_file.size()>0) {
                 context.use_certificate_chain_file(cert_file);
-                context.use_private_key_file(private_key_file, boost::asio::ssl::context::pem);
+                context.use_private_key_file(private_key_file, asio_ns::ssl::context::pem);
             }
             
             if(verify_certificate)
-                context.set_verify_callback(boost::asio::ssl::rfc2818_verification(host));
+                context.set_verify_callback(asio_ns::ssl::rfc2818_verification(host));
             
             if(verify_file.size()>0)
                 context.load_verify_file(verify_file);
@@ -28,25 +28,25 @@ namespace SimpleWeb {
                 context.set_default_verify_paths();
             
             if(verify_file.size()>0 || verify_certificate)
-                context.set_verify_mode(boost::asio::ssl::verify_peer);
+                context.set_verify_mode(asio_ns::ssl::verify_peer);
             else
-                context.set_verify_mode(boost::asio::ssl::verify_none);
+                context.set_verify_mode(asio_ns::ssl::verify_none);
         }
 
     protected:
-        boost::asio::ssl::context context;
+        asio_ns::ssl::context context;
         
         void connect() {
             if(!socket || !socket->lowest_layer().is_open()) {
-                std::unique_ptr<boost::asio::ip::tcp::resolver::query> query;
+                std::unique_ptr<asio_ns::ip::tcp::resolver::query> query;
                 if(config.proxy_server.empty())
-                    query=std::unique_ptr<boost::asio::ip::tcp::resolver::query>(new boost::asio::ip::tcp::resolver::query(host, std::to_string(port)));
+                    query=std::unique_ptr<asio_ns::ip::tcp::resolver::query>(new asio_ns::ip::tcp::resolver::query(host, std::to_string(port)));
                 else {
                     auto proxy_host_port=parse_host_port(config.proxy_server, 8080);
-                    query=std::unique_ptr<boost::asio::ip::tcp::resolver::query>(new boost::asio::ip::tcp::resolver::query(proxy_host_port.first, std::to_string(proxy_host_port.second)));
+                    query=std::unique_ptr<asio_ns::ip::tcp::resolver::query>(new asio_ns::ip::tcp::resolver::query(proxy_host_port.first, std::to_string(proxy_host_port.second)));
                 }
                 resolver.async_resolve(*query, [this]
-                                       (const boost::system::error_code &ec, boost::asio::ip::tcp::resolver::iterator it){
+                                       (const error_ns::error_code &ec, asio_ns::ip::tcp::resolver::iterator it){
                     if(!ec) {
                         {
                             std::lock_guard<std::mutex> lock(socket_mutex);
@@ -54,44 +54,44 @@ namespace SimpleWeb {
                         }
                         
                         auto timer=get_timeout_timer(config.timeout_connect);
-                        boost::asio::async_connect(socket->lowest_layer(), it, [this, timer]
-                                                   (const boost::system::error_code &ec, boost::asio::ip::tcp::resolver::iterator /*it*/){
+                        asio_ns::async_connect(socket->lowest_layer(), it, [this, timer]
+                                                   (const error_ns::error_code &ec, asio_ns::ip::tcp::resolver::iterator /*it*/){
                             if(timer)
                                 timer->cancel();
                             if(!ec) {
-                                boost::asio::ip::tcp::no_delay option(true);
+                                asio_ns::ip::tcp::no_delay option(true);
                                 this->socket->lowest_layer().set_option(option);
                             }
                             else {
                                 std::lock_guard<std::mutex> lock(socket_mutex);
                                 this->socket=nullptr;
-                                throw boost::system::system_error(ec);
+                                throw error_ns::system_error(ec);
                             }
                         });
                     }
                     else {
                         std::lock_guard<std::mutex> lock(socket_mutex);
                         socket=nullptr;
-                        throw boost::system::system_error(ec);
+                        throw error_ns::system_error(ec);
                     }
                 });
                 io_service.reset();
                 io_service.run();
                 
                 if(!config.proxy_server.empty()) {
-                    boost::asio::streambuf write_buffer;
+                    asio_ns::streambuf write_buffer;
                     std::ostream write_stream(&write_buffer);
                     auto host_port=host+':'+std::to_string(port);
                     write_stream << "CONNECT "+host_port+" HTTP/1.1\r\n" << "Host: " << host_port << "\r\n\r\n";
                     auto timer=get_timeout_timer();
-                    boost::asio::async_write(socket->next_layer(), write_buffer,
-                                             [this, timer](const boost::system::error_code &ec, size_t /*bytes_transferred*/) {
+                    asio_ns::async_write(socket->next_layer(), write_buffer,
+                                             [this, timer](const error_ns::error_code &ec, size_t /*bytes_transferred*/) {
                         if(timer)
                             timer->cancel();
                         if(ec) {
                             std::lock_guard<std::mutex> lock(socket_mutex);
                             socket=nullptr;
-                            throw boost::system::system_error(ec);
+                            throw error_ns::system_error(ec);
                         }
                     });
                     io_service.reset();
@@ -99,14 +99,14 @@ namespace SimpleWeb {
                     
                     std::shared_ptr<Response> response(new Response());
                     timer=get_timeout_timer();
-                    boost::asio::async_read_until(socket->next_layer(), response->content_buffer, "\r\n\r\n",
-                                                  [this, timer](const boost::system::error_code& ec, size_t /*bytes_transferred*/) {
+                    asio_ns::async_read_until(socket->next_layer(), response->content_buffer, "\r\n\r\n",
+                                                  [this, timer](const error_ns::error_code& ec, size_t /*bytes_transferred*/) {
                         if(timer)
                             timer->cancel();
                         if(ec) {
                             std::lock_guard<std::mutex> lock(socket_mutex);
                             socket=nullptr;
-                            throw boost::system::system_error(ec);
+                            throw error_ns::system_error(ec);
                         }
                     });
                     io_service.reset();
@@ -115,19 +115,19 @@ namespace SimpleWeb {
                     if (response->status_code.empty() || response->status_code.compare(0, 3, "200") != 0) {
                         std::lock_guard<std::mutex> lock(socket_mutex);
                         socket=nullptr;
-                        throw boost::system::system_error(boost::system::error_code(boost::system::errc::permission_denied, boost::system::generic_category()));
+                        throw merror_ns::make_error_code(error_ns::errc::permission_denied);
                     }
                 }
                 
                 auto timer=get_timeout_timer();
-                this->socket->async_handshake(boost::asio::ssl::stream_base::client,
-                                              [this, timer](const boost::system::error_code& ec) {
+                this->socket->async_handshake(asio_ns::ssl::stream_base::client,
+                                              [this, timer](const error_ns::error_code& ec) {
                     if(timer)
                         timer->cancel();
                     if(ec) {
                         std::lock_guard<std::mutex> lock(socket_mutex);
                         socket=nullptr;
-                        throw boost::system::system_error(ec);
+                        throw error_ns::system_error(ec);
                     }
                 });
                 io_service.reset();

--- a/http_examples.cpp
+++ b/http_examples.cpp
@@ -196,7 +196,7 @@ void default_resource_send(const HttpServer &server, const shared_ptr<HttpServer
     if((read_length=ifs->read(&buffer[0], buffer.size()).gcount())>0) {
         response->write(&buffer[0], read_length);
         if(read_length==static_cast<streamsize>(buffer.size())) {
-            server.send(response, [&server, response, ifs](const boost::system::error_code &ec) {
+            server.send(response, [&server, response, ifs](const error_ns::error_code &ec) {
                 if(!ec)
                     default_resource_send(server, response, ifs);
                 else

--- a/https_examples.cpp
+++ b/https_examples.cpp
@@ -1,3 +1,4 @@
+#define NO_BOOST
 #include "server_https.hpp"
 #include "client_https.hpp"
 
@@ -193,7 +194,7 @@ void default_resource_send(const HttpsServer &server, const shared_ptr<HttpsServ
     if((read_length=ifs->read(&buffer[0], buffer.size()).gcount())>0) {
         response->write(&buffer[0], read_length);
         if(read_length==static_cast<streamsize>(buffer.size())) {
-            server.send(response, [&server, response, ifs](const boost::system::error_code &ec) {
+            server.send(response, [&server, response, ifs](const error_ns::error_code &ec) {
                 if(!ec)
                     default_resource_send(server, response, ifs);
                 else

--- a/https_examples.cpp
+++ b/https_examples.cpp
@@ -1,4 +1,3 @@
-#define NO_BOOST
 #include "server_https.hpp"
 #include "client_https.hpp"
 

--- a/server_http.hpp
+++ b/server_http.hpp
@@ -1,10 +1,6 @@
 #ifndef SERVER_HTTP_HPP
 #define	SERVER_HTTP_HPP
 
-#include <boost/asio.hpp>
-#include <boost/algorithm/string/predicate.hpp>
-#include <boost/functional/hash.hpp>
-
 #include <map>
 #include <unordered_map>
 #include <thread>
@@ -12,8 +8,57 @@
 #include <iostream>
 #include <sstream>
 
-#ifndef CASE_INSENSITIVE_EQUALS_AND_HASH
-#define CASE_INSENSITIVE_EQUALS_AND_HASH
+#ifdef NO_BOOST
+#include <asio.hpp>
+#include <type_traits>
+#include <system_error>
+namespace   asio_ns = asio;
+namespace  error_ns = std;
+namespace merror_ns = std;
+# ifndef CASE_INSENSITIVE_EQUALS_AND_HASH
+# define CASE_INSENSITIVE_EQUALS_AND_HASH
+class case_insensitive_equals {
+public:
+  bool operator()(const std::string &Left, const std::string &Right) const {
+	return Left.size() == Right.size() 
+		&& std::equal ( Left.begin() , Left.end() , Right.begin() ,
+		[]( char a , char b ) {
+		return tolower(a) == tolower(b); 
+	});
+  }
+};
+bool IEQUALS(const std::string& Left, const std::string& Right)
+{
+	return Left.size() == Right.size() 
+		&& std::equal ( Left.begin() , Left.end() , Right.begin() , []( char a , char b ) {
+			return tolower(a) == tolower(b); 
+	});
+}
+class case_insensitive_hash {
+public:
+    size_t operator()(const std::string& Keyval) const
+    {
+	//You might need a better hash function than this
+	size_t h = 0;
+	std::for_each( Keyval.begin() , Keyval.end() , [&](char c ) {
+		h += tolower(c);
+	});
+	return h;
+    }
+};
+# endif
+
+#else
+#include <boost/asio.hpp>
+#include <boost/algorithm/string/predicate.hpp>
+#include <boost/functional/hash.hpp>
+namespace   asio_ns = boost::asio;
+namespace  error_ns = boost::system;
+namespace merror_ns = boost::system::errc;
+
+# ifndef CASE_INSENSITIVE_EQUALS_AND_HASH
+# define CASE_INSENSITIVE_EQUALS_AND_HASH
+# define IEQUALS boost::iequals
 //Based on http://www.boost.org/doc/libs/1_60_0/doc/html/unordered/hash_equality.html
 class case_insensitive_equals {
 public:
@@ -30,15 +75,16 @@ public:
     return seed;
   }
 };
-#endif
+# endif
 
+#endif
 // Late 2017 TODO: remove the following checks and always use std::regex
 #ifdef USE_BOOST_REGEX
 #include <boost/regex.hpp>
-#define REGEX_NS boost
+namespace regex_ns = boost;
 #else
 #include <regex>
-#define REGEX_NS std
+namespace regex_ns = std;
 #endif
 
 // TODO when switching to c++14, use [[deprecated]] instead
@@ -64,7 +110,7 @@ namespace SimpleWeb {
         class Response : public std::ostream {
             friend class ServerBase<socket_type>;
 
-            boost::asio::streambuf streambuf;
+            asio_ns::streambuf streambuf;
 
             std::shared_ptr<socket_type> socket;
 
@@ -94,8 +140,8 @@ namespace SimpleWeb {
                 return ss.str();
             }
         private:
-            boost::asio::streambuf &streambuf;
-            Content(boost::asio::streambuf &streambuf): std::istream(&streambuf), streambuf(streambuf) {}
+            asio_ns::streambuf &streambuf;
+            Content(asio_ns::streambuf &streambuf): std::istream(&streambuf), streambuf(streambuf) {}
         };
         
         class Request {
@@ -108,7 +154,7 @@ namespace SimpleWeb {
 
             std::unordered_multimap<std::string, std::string, case_insensitive_hash, case_insensitive_equals> header;
 
-            REGEX_NS::smatch path_match;
+            regex_ns::smatch path_match;
             
             std::string remote_endpoint_address;
             unsigned short remote_endpoint_port;
@@ -119,10 +165,10 @@ namespace SimpleWeb {
                 auto qs_start_pos = path.find('?');
                 if (qs_start_pos != std::string::npos && qs_start_pos + 1 < path.size()) {
                     ++qs_start_pos;
-                    static REGEX_NS::regex pattern("([\\w+%]+)=?([^&]*)");
+                    static regex_ns::regex pattern("([\\w+%]+)=?([^&]*)");
                     int submatches[] = {1, 2};
-                    auto it_begin = REGEX_NS::sregex_token_iterator(path.begin() + qs_start_pos, path.end(), pattern, submatches);
-                    auto it_end = REGEX_NS::sregex_token_iterator();
+                    auto it_begin = regex_ns::sregex_token_iterator(path.begin() + qs_start_pos, path.end(), pattern, submatches);
+                    auto it_end = regex_ns::sregex_token_iterator();
                     for (auto it = it_begin; it != it_end; ++it) {
                         auto submatch1=it->str();
                         auto submatch2=(++it)->str();
@@ -151,7 +197,7 @@ namespace SimpleWeb {
                 catch(...) {}
             }
             
-            boost::asio::streambuf streambuf;
+            asio_ns::streambuf streambuf;
         };
         
         class Config {
@@ -177,11 +223,11 @@ namespace SimpleWeb {
         Config config;
         
     private:
-        class regex_orderable : public REGEX_NS::regex {
+        class regex_orderable : public regex_ns::regex {
             std::string str;
         public:
-            regex_orderable(const char *regex_cstr) : REGEX_NS::regex(regex_cstr), str(regex_cstr) {}
-            regex_orderable(const std::string &regex_str) : REGEX_NS::regex(regex_str), str(regex_str) {}
+            regex_orderable(const char *regex_cstr) : regex_ns::regex(regex_cstr), str(regex_cstr) {}
+            regex_orderable(const std::string &regex_str) : regex_ns::regex(regex_str), str(regex_str) {}
             bool operator<(const regex_orderable &rhs) const {
                 return str<rhs.str;
             }
@@ -194,27 +240,27 @@ namespace SimpleWeb {
         std::map<std::string,
             std::function<void(std::shared_ptr<typename ServerBase<socket_type>::Response>, std::shared_ptr<typename ServerBase<socket_type>::Request>)> > default_resource;
         
-        std::function<void(std::shared_ptr<typename ServerBase<socket_type>::Request>, const boost::system::error_code&)> on_error;
+        std::function<void(std::shared_ptr<typename ServerBase<socket_type>::Request>, const error_ns::error_code&)> on_error;
         
         std::function<void(std::shared_ptr<socket_type> socket, std::shared_ptr<typename ServerBase<socket_type>::Request>)> on_upgrade;
         
         virtual void start() {
             if(!io_service)
-                io_service=std::make_shared<boost::asio::io_service>();
+                io_service=std::make_shared<asio_ns::io_service>();
 
             if(io_service->stopped())
                 io_service->reset();
 
-            boost::asio::ip::tcp::endpoint endpoint;
+            asio_ns::ip::tcp::endpoint endpoint;
             if(config.address.size()>0)
-                endpoint=boost::asio::ip::tcp::endpoint(boost::asio::ip::address::from_string(config.address), config.port);
+                endpoint=asio_ns::ip::tcp::endpoint(asio_ns::ip::address::from_string(config.address), config.port);
             else
-                endpoint=boost::asio::ip::tcp::endpoint(boost::asio::ip::tcp::v4(), config.port);
+                endpoint=asio_ns::ip::tcp::endpoint(asio_ns::ip::tcp::v4(), config.port);
             
             if(!acceptor)
-                acceptor=std::unique_ptr<boost::asio::ip::tcp::acceptor>(new boost::asio::ip::tcp::acceptor(*io_service));
+                acceptor=std::unique_ptr<asio_ns::ip::tcp::acceptor>(new asio_ns::ip::tcp::acceptor(*io_service));
             acceptor->open(endpoint.protocol());
-            acceptor->set_option(boost::asio::socket_base::reuse_address(config.reuse_address));
+            acceptor->set_option(asio_ns::socket_base::reuse_address(config.reuse_address));
             acceptor->bind(endpoint);
             acceptor->listen();
      
@@ -245,34 +291,34 @@ namespace SimpleWeb {
         }
         
         ///Use this function if you need to recursively send parts of a longer message
-        void send(const std::shared_ptr<Response> &response, const std::function<void(const boost::system::error_code&)>& callback=nullptr) const {
-            boost::asio::async_write(*response->socket, response->streambuf, [this, response, callback](const boost::system::error_code& ec, size_t /*bytes_transferred*/) {
+        void send(const std::shared_ptr<Response> &response, const std::function<void(const error_ns::error_code&)>& callback=nullptr) const {
+            asio_ns::async_write(*response->socket, response->streambuf, [this, response, callback](const error_ns::error_code& ec, size_t /*bytes_transferred*/) {
                 if(callback)
                     callback(ec);
             });
         }
 
-        /// If you have your own boost::asio::io_service, store its pointer here before running start().
+        /// If you have your own asio_ns::io_service, store its pointer here before running start().
         /// You might also want to set config.thread_pool_size to 0.
-        std::shared_ptr<boost::asio::io_service> io_service;
+        std::shared_ptr<asio_ns::io_service> io_service;
     protected:
-        std::unique_ptr<boost::asio::ip::tcp::acceptor> acceptor;
+        std::unique_ptr<asio_ns::ip::tcp::acceptor> acceptor;
         std::vector<std::thread> threads;
         
         ServerBase(unsigned short port) : config(port) {}
         
         virtual void accept()=0;
         
-        std::shared_ptr<boost::asio::deadline_timer> get_timeout_timer(const std::shared_ptr<socket_type> &socket, long seconds) {
+        std::shared_ptr<asio_ns::deadline_timer> get_timeout_timer(const std::shared_ptr<socket_type> &socket, long seconds) {
             if(seconds==0)
                 return nullptr;
             
-            auto timer=std::make_shared<boost::asio::deadline_timer>(*io_service);
+            auto timer=std::make_shared<asio_ns::deadline_timer>(*io_service);
             timer->expires_from_now(boost::posix_time::seconds(seconds));
-            timer->async_wait([socket](const boost::system::error_code& ec){
+            timer->async_wait([socket](const error_ns::error_code& ec){
                 if(!ec) {
-                    boost::system::error_code ec;
-                    socket->lowest_layer().shutdown(boost::asio::ip::tcp::socket::shutdown_both, ec);
+                    error_ns::error_code ec;
+                    socket->lowest_layer().shutdown(asio_ns::ip::tcp::socket::shutdown_both, ec);
                     socket->lowest_layer().close();
                 }
             });
@@ -284,11 +330,11 @@ namespace SimpleWeb {
             //shared_ptr is used to pass temporary objects to the asynchronous functions
             std::shared_ptr<Request> request(new Request(*socket));
 
-            //Set timeout on the following boost::asio::async-read or write function
+            //Set timeout on the following asio_ns::async-read or write function
             auto timer=this->get_timeout_timer(socket, config.timeout_request);
                         
-            boost::asio::async_read_until(*socket, request->streambuf, "\r\n\r\n",
-                    [this, socket, request, timer](const boost::system::error_code& ec, size_t bytes_transferred) {
+            asio_ns::async_read_until(*socket, request->streambuf, "\r\n\r\n",
+                    [this, socket, request, timer](const error_ns::error_code& ec, size_t bytes_transferred) {
                 if(timer)
                     timer->cancel();
                 if(!ec) {
@@ -310,16 +356,16 @@ namespace SimpleWeb {
                         }
                         catch(const std::exception &e) {
                             if(on_error)
-                                on_error(request, boost::system::error_code(boost::system::errc::protocol_error, boost::system::generic_category()));
+                                on_error(request, merror_ns::make_error_code(error_ns::errc::protocol_error));
                             return;
                         }
                         if(content_length>num_additional_bytes) {
-                            //Set timeout on the following boost::asio::async-read or write function
+                            //Set timeout on the following asio_ns::async-read or write function
                             auto timer=this->get_timeout_timer(socket, config.timeout_content);
-                            boost::asio::async_read(*socket, request->streambuf,
-                                    boost::asio::transfer_exactly(content_length-num_additional_bytes),
+                            asio_ns::async_read(*socket, request->streambuf,
+                                    asio_ns::transfer_exactly(content_length-num_additional_bytes),
                                     [this, socket, request, timer]
-                                    (const boost::system::error_code& ec, size_t /*bytes_transferred*/) {
+                                    (const error_ns::error_code& ec, size_t /*bytes_transferred*/) {
                                 if(timer)
                                     timer->cancel();
                                 if(!ec)
@@ -393,8 +439,8 @@ namespace SimpleWeb {
             for(auto &regex_method: resource) {
                 auto it=regex_method.second.find(request->method);
                 if(it!=regex_method.second.end()) {
-                    REGEX_NS::smatch sm_res;
-                    if(REGEX_NS::regex_match(request->path, sm_res, regex_method.first)) {
+                    regex_ns::smatch sm_res;
+                    if(regex_ns::regex_match(request->path, sm_res, regex_method.first)) {
                         request->path_match=std::move(sm_res);
                         write_response(socket, request, it->second);
                         return;
@@ -410,12 +456,12 @@ namespace SimpleWeb {
         void write_response(const std::shared_ptr<socket_type> &socket, const std::shared_ptr<Request> &request, 
                 std::function<void(std::shared_ptr<typename ServerBase<socket_type>::Response>,
                                    std::shared_ptr<typename ServerBase<socket_type>::Request>)>& resource_function) {
-            //Set timeout on the following boost::asio::async-read or write function
+            //Set timeout on the following asio_ns::async-read or write function
             auto timer=this->get_timeout_timer(socket, config.timeout_content);
 
             auto response=std::shared_ptr<Response>(new Response(socket), [this, request, timer](Response *response_ptr) {
                 auto response=std::shared_ptr<Response>(response_ptr);
-                this->send(response, [this, response, request, timer](const boost::system::error_code& ec) {
+                this->send(response, [this, response, request, timer](const error_ns::error_code& ec) {
                     if(timer)
                         timer->cancel();
                     if(!ec) {
@@ -424,9 +470,9 @@ namespace SimpleWeb {
 
                         auto range=request->header.equal_range("Connection");
                         for(auto it=range.first;it!=range.second;it++) {
-                            if(boost::iequals(it->second, "close")) {
+                            if(IEQUALS(it->second, "close")) {
                                 return;
-                            } else if (boost::iequals(it->second, "keep-alive")) {
+                            } else if (IEQUALS(it->second, "keep-alive")) {
                                 this->read_request_and_content(response->socket);
                                 return;
                             }
@@ -444,7 +490,7 @@ namespace SimpleWeb {
             }
             catch(const std::exception &e) {
                 if(on_error)
-                    on_error(request, boost::system::error_code(boost::system::errc::operation_canceled, boost::system::generic_category()));
+                    on_error(request, merror_ns::make_error_code(error_ns::errc::operation_canceled));
                 return;
             }
         }
@@ -453,7 +499,7 @@ namespace SimpleWeb {
     template<class socket_type>
     class Server : public ServerBase<socket_type> {};
     
-    typedef boost::asio::ip::tcp::socket HTTP;
+    typedef asio_ns::ip::tcp::socket HTTP;
     
     template<>
     class Server<HTTP> : public ServerBase<HTTP> {
@@ -474,13 +520,13 @@ namespace SimpleWeb {
             //Shared_ptr is used to pass temporary objects to the asynchronous functions
             auto socket=std::make_shared<HTTP>(*io_service);
                         
-            acceptor->async_accept(*socket, [this, socket](const boost::system::error_code& ec){
+            acceptor->async_accept(*socket, [this, socket](const error_ns::error_code& ec){
                 //Immediately start accepting a new connection (if io_service hasn't been stopped)
-                if (ec != boost::asio::error::operation_aborted)
+                if (ec != asio_ns::error::operation_aborted)
                     accept();
                                 
                 if(!ec) {
-                    boost::asio::ip::tcp::no_delay option(true);
+                    asio_ns::ip::tcp::no_delay option(true);
                     socket->set_option(option);
                     
                     this->read_request_and_content(socket);

--- a/server_https.hpp
+++ b/server_https.hpp
@@ -2,12 +2,16 @@
 #define	SERVER_HTTPS_HPP
 
 #include "server_http.hpp"
-#include <boost/asio/ssl.hpp>
+#ifdef NO_BOOST
+# include <asio/ssl.hpp>
+#else
+# include <boost/asio/ssl.hpp>
+#endif
 #include <openssl/ssl.h>
 #include <algorithm>
 
 namespace SimpleWeb {
-    typedef boost::asio::ssl::stream<boost::asio::ip::tcp::socket> HTTPS;    
+    typedef asio_ns::ssl::stream<asio_ns::ip::tcp::socket> HTTPS;    
     
     template<>
     class Server<HTTPS> : public ServerBase<HTTPS> {
@@ -25,14 +29,14 @@ namespace SimpleWeb {
         }
         
         Server(const std::string& cert_file, const std::string& private_key_file, const std::string& verify_file=std::string()):
-                ServerBase<HTTPS>::ServerBase(443), context(boost::asio::ssl::context::tlsv12) {
+                ServerBase<HTTPS>::ServerBase(443), context(asio_ns::ssl::context::tlsv12) {
             context.use_certificate_chain_file(cert_file);
-            context.use_private_key_file(private_key_file, boost::asio::ssl::context::pem);
+            context.use_private_key_file(private_key_file, asio_ns::ssl::context::pem);
             
             if(verify_file.size()>0) {
                 context.load_verify_file(verify_file);
-                context.set_verify_mode(boost::asio::ssl::verify_peer | boost::asio::ssl::verify_fail_if_no_peer_cert |
-                                        boost::asio::ssl::verify_client_once);
+                context.set_verify_mode(asio_ns::ssl::verify_peer | asio_ns::ssl::verify_fail_if_no_peer_cert |
+                                        asio_ns::ssl::verify_client_once);
                 set_session_id_context=true;
             }
         }
@@ -49,27 +53,27 @@ namespace SimpleWeb {
         }
 
     protected:
-        boost::asio::ssl::context context;
+        asio_ns::ssl::context context;
         
         void accept() {
             //Create new socket for this connection
             //Shared_ptr is used to pass temporary objects to the asynchronous functions
             auto socket=std::make_shared<HTTPS>(*io_service, context);
 
-            acceptor->async_accept((*socket).lowest_layer(), [this, socket](const boost::system::error_code& ec) {
+            acceptor->async_accept((*socket).lowest_layer(), [this, socket](const error_ns::error_code& ec) {
                 //Immediately start accepting a new connection (if io_service hasn't been stopped)
-                if (ec != boost::asio::error::operation_aborted)
+                if (ec != asio_ns::error::operation_aborted)
                     accept();
 
                 
                 if(!ec) {
-                    boost::asio::ip::tcp::no_delay option(true);
+                    asio_ns::ip::tcp::no_delay option(true);
                     socket->lowest_layer().set_option(option);
                     
-                    //Set timeout on the following boost::asio::ssl::stream::async_handshake
+                    //Set timeout on the following asio_ns::ssl::stream::async_handshake
                     auto timer=get_timeout_timer(socket, config.timeout_request);
-                    socket->async_handshake(boost::asio::ssl::stream_base::server, [this, socket, timer]
-                            (const boost::system::error_code& ec) {
+                    socket->async_handshake(asio_ns::ssl::stream_base::server, [this, socket, timer]
+                            (const error_ns::error_code& ec) {
                         if(timer)
                             timer->cancel();
                         if(!ec)


### PR DESCRIPTION
Same goal as previous PR : Remove Boost dependency.
Change compared to previous PR :
- define namespace instead of C macros
- using boost keep being the default
- no cmake changes
- define NO_BOOST to have the expected behaviour