### PR TITLE
Removed dependency of boost::deadline_timer if USE_STANDALONE_ASIO is defined.

### DIFF
--- a/server_http.hpp
+++ b/server_http.hpp
@@ -12,6 +12,7 @@
 
 #ifdef USE_STANDALONE_ASIO
 #include <asio.hpp>
+#include <asio/basic_waitable_timer.hpp>
 namespace SimpleWeb {
   using error_code = std::error_code;
   using errc = std::errc;
@@ -19,6 +20,7 @@ namespace SimpleWeb {
 } // namespace SimpleWeb
 #else
 #include <boost/asio.hpp>
+#include <boost/asio/steady_timer.hpp>
 namespace SimpleWeb {
   namespace asio = boost::asio;
   using error_code = boost::system::error_code;
@@ -214,7 +216,7 @@ namespace SimpleWeb {
       std::unique_ptr<socket_type> socket; // Socket must be unique_ptr since asio::ssl::stream<asio::ip::tcp::socket> is not movable
       std::mutex socket_close_mutex;
 
-      std::unique_ptr<asio::deadline_timer> timer;
+      std::unique_ptr<asio::steady_timer> timer;
 
       void close() noexcept {
         error_code ec;
@@ -229,8 +231,8 @@ namespace SimpleWeb {
           return;
         }
 
-        timer = std::unique_ptr<asio::deadline_timer>(new asio::deadline_timer(socket->get_io_service()));
-        timer->expires_from_now(boost::posix_time::seconds(seconds));
+        timer = std::unique_ptr<asio::steady_timer>(new asio::steady_timer(socket->get_io_service()));
+        timer->expires_from_now(std::chrono::seconds(seconds));
         auto self = this->shared_from_this();
         timer->async_wait([self](const error_code &ec) {
           if(!ec)


### PR DESCRIPTION
* Removed dependency of boost::deadline_timer if USE_STANDALONE_ASIO is defined.