### PR TITLE
Change 'typedef' constructions to type aliases

### DIFF
--- a/client_http.hpp
+++ b/client_http.hpp
@@ -594,7 +594,7 @@ namespace SimpleWeb {
   template <class socket_type>
   class Client : public ClientBase<socket_type> {};
 
-  typedef asio::ip::tcp::socket HTTP;
+  using HTTP = asio::ip::tcp::socket;
 
   template <>
   class Client<HTTP> : public ClientBase<HTTP> {

--- a/client_https.hpp
+++ b/client_https.hpp
@@ -10,7 +10,7 @@
 #endif
 
 namespace SimpleWeb {
-  typedef asio::ssl::stream<asio::ip::tcp::socket> HTTPS;
+  using HTTPS = asio::ssl::stream<asio::ip::tcp::socket>;
 
   template <>
   class Client<HTTPS> : public ClientBase<HTTPS> {

--- a/http_examples.cpp
+++ b/http_examples.cpp
@@ -19,8 +19,8 @@ using namespace std;
 // Added for the json-example:
 using namespace boost::property_tree;
 
-typedef SimpleWeb::Server<SimpleWeb::HTTP> HttpServer;
-typedef SimpleWeb::Client<SimpleWeb::HTTP> HttpClient;
+using HttpServer = SimpleWeb::Server<SimpleWeb::HTTP>;
+using HttpClient = SimpleWeb::Client<SimpleWeb::HTTP>;
 
 int main() {
   // HTTP-server at port 8080 using 1 thread

--- a/https_examples.cpp
+++ b/https_examples.cpp
@@ -17,8 +17,8 @@ using namespace std;
 // Added for the json-example:
 using namespace boost::property_tree;
 
-typedef SimpleWeb::Server<SimpleWeb::HTTPS> HttpsServer;
-typedef SimpleWeb::Client<SimpleWeb::HTTPS> HttpsClient;
+using HttpsServer = SimpleWeb::Server<SimpleWeb::HTTPS>;
+using HttpsClient = SimpleWeb::Client<SimpleWeb::HTTPS>;
 
 int main() {
   // HTTPS-server at port 8080 using 1 thread

--- a/server_http.hpp
+++ b/server_http.hpp
@@ -551,7 +551,7 @@ namespace SimpleWeb {
   template <class socket_type>
   class Server : public ServerBase<socket_type> {};
 
-  typedef asio::ip::tcp::socket HTTP;
+  using HTTP = asio::ip::tcp::socket;
 
   template <>
   class Server<HTTP> : public ServerBase<HTTP> {

--- a/server_https.hpp
+++ b/server_https.hpp
@@ -13,7 +13,7 @@
 #include <openssl/ssl.h>
 
 namespace SimpleWeb {
-  typedef asio::ssl::stream<asio::ip::tcp::socket> HTTPS;
+  using HTTPS = asio::ssl::stream<asio::ip::tcp::socket>;
 
   template <>
   class Server<HTTPS> : public ServerBase<HTTPS> {

--- a/tests/io_test.cpp
+++ b/tests/io_test.cpp
@@ -9,8 +9,8 @@ using namespace std;
 namespace asio = boost::asio;
 #endif
 
-typedef SimpleWeb::Server<SimpleWeb::HTTP> HttpServer;
-typedef SimpleWeb::Client<SimpleWeb::HTTP> HttpClient;
+using HttpServer = SimpleWeb::Server<SimpleWeb::HTTP>;
+using HttpClient = SimpleWeb::Client<SimpleWeb::HTTP>;
 
 int main() {
   // Test ScopeRunner

--- a/utility.hpp
+++ b/utility.hpp
@@ -33,7 +33,7 @@ namespace SimpleWeb {
     }
   };
 
-  typedef std::unordered_multimap<std::string, std::string, CaseInsensitiveHash, CaseInsensitiveEqual> CaseInsensitiveMultimap;
+  using CaseInsensitiveMultimap = std::unordered_multimap<std::string, std::string, CaseInsensitiveHash, CaseInsensitiveEqual>;
 
   /// Percent encoding and decoding
   class Percent {


### PR DESCRIPTION
I think it's a good idea to use this feature from C++11.