### PR TITLE
Fixed build problems mainly for Windows and Visual C++

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ io_test
 parse_test
 crypto_test
 status_code_test
+
+build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,27 +1,31 @@
 cmake_minimum_required (VERSION 2.8.8)
 project (Simple-Web-Server)
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -Wextra -Wsign-conversion")
+
+if(MSVC)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /W1")
+elseif(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14 -Wall -Wextra -Wsign-conversion")
+endif()
 
 include_directories(.)
 
 find_package(Threads REQUIRED)
 
-set(BOOST_COMPONENTS system filesystem thread)
-# Late 2017 TODO: remove the following checks and always use std::regex
-if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
-    if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 4.9)
-        set(BOOST_COMPONENTS ${BOOST_COMPONENTS} regex)
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DUSE_BOOST_REGEX")
-    endif()
+if(MSVC)
+ set(Boost_USE_STATIC_LIBS ON)
+ set(Boost_USE_MULTITHREADED ON)
 endif()
+
+set(BOOST_COMPONENTS system filesystem thread)
 find_package(Boost 1.53.0 COMPONENTS ${BOOST_COMPONENTS} REQUIRED)
 include_directories(SYSTEM ${Boost_INCLUDE_DIR})
+link_directories(${Boost_LIBRARY_DIRS})
 
 if(APPLE)
     set(OPENSSL_ROOT_DIR "/usr/local/opt/openssl")
 endif()
 
-add_executable(http_examples http_examples.cpp)
+add_executable(http_examples http_examples.cpp client_http.hpp server_http.hpp status_code.hpp utility.hpp)
 target_link_libraries(http_examples ${Boost_LIBRARIES})
 target_link_libraries(http_examples ${CMAKE_THREAD_LIBS_INIT})
 
@@ -33,7 +37,7 @@ if(OPENSSL_FOUND)
     target_link_libraries(http_examples ${OPENSSL_LIBRARIES})
     include_directories(SYSTEM ${OPENSSL_INCLUDE_DIR})
 
-    add_executable(https_examples https_examples.cpp)
+    add_executable(https_examples https_examples.cpp client_http.hpp client_https.hpp server_http.hpp server_https.hpp status_code.hpp utility.hpp)
     target_link_libraries(https_examples ${Boost_LIBRARIES})
     target_link_libraries(https_examples ${OPENSSL_LIBRARIES})
     target_link_libraries(https_examples ${CMAKE_THREAD_LIBS_INIT})

--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ See particularly the JSON-POST (using Boost.PropertyTree) and the GET /match/[nu
 
 ### Compile and run
 
+#### On Unix like systems
+
 Compile with a C++11 compliant compiler:
 ```sh
 mkdir build
@@ -38,6 +40,18 @@ cmake ..
 make
 cd ..
 ```
+
+#### On Windows with Visual C++
+Open Visual developer prompt
+```cmd
+set BOOST_ROOT=C:/libs/boost
+set OPENSSL_ROOT_DIR=C:/Program Files (x86)/OpenSSL
+mkdir build
+cd build
+cmake-gui ..
+```
+Press Configure, then Generate
+Open the Simple-Web-Server.sln
 
 #### HTTP
 

--- a/client_https.hpp
+++ b/client_https.hpp
@@ -84,15 +84,15 @@ namespace SimpleWeb {
                         if(!lock)
                           return;
                         if((!ec || ec == asio::error::not_found) && response->streambuf.size() == response->streambuf.max_size()) {
-                          session->callback(session->connection, make_error_code::make_error_code(errc::message_size));
+                          session->callback(session->connection, merrc::make_error_code(errc::message_size));
                           return;
                         }
                         if(!ec) {
                           if(!ResponseMessage::parse(response->content, response->http_version, response->status_code, response->header))
-                            session->callback(session->connection, make_error_code::make_error_code(errc::protocol_error));
+                            session->callback(session->connection, merrc::make_error_code(errc::protocol_error));
                           else {
                             if(response->status_code.empty() || response->status_code.compare(0, 3, "200") != 0)
-                              session->callback(session->connection, make_error_code::make_error_code(errc::permission_denied));
+                              session->callback(session->connection, merrc::make_error_code(errc::permission_denied));
                             else
                               this->handshake(session);
                           }

--- a/http_examples.cpp
+++ b/http_examples.cpp
@@ -247,7 +247,7 @@ int main() {
 
       header.emplace("Content-Length", to_string(ss.str().size()));
       response->write(header);
-      response->write(ss.str().c_str(), ss.str().size());
+      response->write(ss.str().c_str(), (std::streamsize)ss.str().size());
       response->send();
     }
     catch (const exception &e) {

--- a/http_examples.cpp
+++ b/http_examples.cpp
@@ -207,6 +207,7 @@ int main() {
         throw invalid_argument("could not read file");
     }
     catch(const exception &e) {
+      std::cout << "Error within GET: " << e.what() << std::endl;
       response->write(SimpleWeb::StatusCode::client_error_bad_request, "Could not open path " + request->path + ": " + e.what());
     }
   };

--- a/http_examples.cpp
+++ b/http_examples.cpp
@@ -212,6 +212,50 @@ int main() {
     }
   };
 
+  server.default_resource["POST"] = [](shared_ptr<HttpServer::Response> response, shared_ptr<HttpServer::Request> request) {
+    try {
+      char contentbuf[128];
+      stringstream ss;
+      ss << "Post repost q: " << request->query_string << " p: " << request->path << " cont: ";
+      while (request->content.getline(contentbuf, 128))
+        ss << contentbuf;
+
+      SimpleWeb::CaseInsensitiveMultimap header;
+
+      //    Uncomment the following line to enable Cache-Control
+      //    header.emplace("Cache-Control", "max-age=86400");
+
+  #ifdef HAVE_OPENSSL
+      //    Uncomment the following lines to enable ETag
+      //    {
+      //      ifstream ifs(path.string(), ifstream::in | ios::binary);
+      //      if(ifs) {
+      //        auto hash = SimpleWeb::Crypto::to_hex_string(SimpleWeb::Crypto::md5(ifs));
+      //        header.emplace("ETag", "\"" + hash + "\"");
+      //        auto it = request->header.find("If-None-Match");
+      //        if(it != request->header.end()) {
+      //          if(!it->second.empty() && it->second.compare(1, hash.size(), hash) == 0) {
+      //            response->write(SimpleWeb::StatusCode::redirection_not_modified, header);
+      //            return;
+      //          }
+      //        }
+      //      }
+      //      else
+      //        throw invalid_argument("could not read file");
+      //    }
+  #endif
+
+      header.emplace("Content-Length", to_string(ss.str().size()));
+      response->write(header);
+      response->write(ss.str().c_str(), ss.str().size());
+      response->send();
+    }
+    catch (const exception &e) {
+        std::cout << "Error within POST: " << e.what() << std::endl;
+        response->write(SimpleWeb::StatusCode::client_error_bad_request, string("Error: ") + e.what());
+    }
+  };
+
   server.on_error = [](shared_ptr<HttpServer::Request> /*request*/, const SimpleWeb::error_code & /*ec*/) {
     // Handle errors here
   };

--- a/https_examples.cpp
+++ b/https_examples.cpp
@@ -24,6 +24,13 @@ int main() {
   // HTTPS-server at port 8080 using 1 thread
   // Unless you do more heavy non-threaded processing in the resources,
   // 1 thread is usually faster than several threads
+  //
+  // You can use:
+  //  openssl genrsa -out server.key
+  //  oopenssl req -new -key server.key -out server.csr
+  //  oopenssl x509 -req -days 365 -in server.csr -signkey server.key -out server.crt
+  // to generate server.crt and server.key files.
+  // For the above openssl should be in your path and execute within servers (this programs) working directory.
   HttpsServer server("server.crt", "server.key");
   server.config.port = 8080;
 

--- a/https_examples.cpp
+++ b/https_examples.cpp
@@ -254,7 +254,7 @@ int main() {
 
       header.emplace("Content-Length", to_string(ss.str().size()));
       response->write(header);
-      response->write(ss.str().c_str(), ss.str().size());
+      response->write(ss.str().c_str(), (std::streamsize)ss.str().size());
       response->send();
     }
     catch (const exception &e)

--- a/https_examples.cpp
+++ b/https_examples.cpp
@@ -205,6 +205,7 @@ int main() {
         throw invalid_argument("could not read file");
     }
     catch(const exception &e) {
+      std::cout << "Error within GET: " << e.what() << std::endl;
       response->write(SimpleWeb::StatusCode::client_error_bad_request, "Could not open path " + request->path + ": " + e.what());
     }
   };

--- a/server_http.hpp
+++ b/server_http.hpp
@@ -172,7 +172,9 @@ namespace SimpleWeb {
       }
 
     private:
+    TEST_ONLY(public:)
       asio::streambuf &streambuf;
+    private:
       Content(asio::streambuf &streambuf) noexcept : std::istream(&streambuf), streambuf(streambuf) {}
     };
 
@@ -181,6 +183,7 @@ namespace SimpleWeb {
       friend class Server<socket_type>;
       friend class Session;
 
+    TEST_ONLY(public:)
       asio::streambuf streambuf;
       Request(size_t max_request_streambuf_size, const std::string &remote_endpoint_address = std::string(), unsigned short remote_endpoint_port = 0) noexcept
           : streambuf(max_request_streambuf_size), content(streambuf), remote_endpoint_address(remote_endpoint_address), remote_endpoint_port(remote_endpoint_port) {}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,10 +1,10 @@
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-access-control")
 
-add_executable(io_test io_test.cpp)
+add_executable(io_test io_test.cpp ../client_http.hpp ../client_https.hpp ../server_http.hpp ../server_https.hpp ../status_code.hpp ../utility.hpp)
 target_link_libraries(io_test ${Boost_LIBRARIES})
 target_link_libraries(io_test ${CMAKE_THREAD_LIBS_INIT})
 
-add_executable(parse_test parse_test.cpp)
+add_executable(parse_test parse_test.cpp ../client_http.hpp ../client_https.hpp ../server_http.hpp ../server_https.hpp ../status_code.hpp ../utility.hpp)
 target_link_libraries(parse_test ${Boost_LIBRARIES})
 target_link_libraries(parse_test ${CMAKE_THREAD_LIBS_INIT})
 
@@ -22,5 +22,5 @@ if(OPENSSL_FOUND)
     add_test(crypto_test crypto_test)
 endif()
 
-add_executable(status_code_test status_code_test.cpp)
+add_executable(status_code_test status_code_test.cpp ../status_code.hpp)
 add_test(status_code_test status_code_test)

--- a/tests/io_test.cpp
+++ b/tests/io_test.cpp
@@ -1,3 +1,4 @@
+#define SIMPLE_WEB_TEST
 #include "client_http.hpp"
 #include "server_http.hpp"
 

--- a/tests/status_code_test.cpp
+++ b/tests/status_code_test.cpp
@@ -1,3 +1,4 @@
+#define SIMPLE_WEB_TEST
 #include "status_code.hpp"
 #include <cassert>
 

--- a/utility.hpp
+++ b/utility.hpp
@@ -8,6 +8,12 @@
 #include <string>
 #include <unordered_map>
 
+#ifdef SIMPLE_WEB_TEST
+# define TEST_ONLY(x) x
+#else
+# define TEST_ONLY(x)
+#endif
+
 namespace SimpleWeb {
   inline bool case_insensitive_equal(const std::string &str1, const std::string &str2) noexcept {
     return str1.size() == str2.size() &&
@@ -296,6 +302,7 @@ namespace SimpleWeb {
 namespace SimpleWeb {
   /// Makes it possible to for instance cancel Asio handlers without stopping asio::io_service
   class ScopeRunner {
+  TEST_ONLY(public:)
     /// Scope count that is set to -1 if scopes are to be canceled
     std::atomic<long> count;
 


### PR DESCRIPTION
Tested on Visual C++ 2017 (15.3) Community Edition, boost 1.65.1, OpenSSL 1.1.0, Cmake 3.9.3 - everything builds, but not all tests pass yet.
Some additional minor changes are:
- additional comments,
- stdout error messages in http(s) examples,
- POST method examples,
- a .gitignore that ignores the build directory.