### PR TITLE
fixed type conversion warning in Visual Studio

### DIFF
--- a/server_http.hpp
+++ b/server_http.hpp
@@ -477,7 +477,7 @@ namespace SimpleWeb {
             }
             if(content_length > num_additional_bytes) {
               session->connection->set_timeout(config.timeout_content);
-              asio::async_read(*session->connection->socket, session->request->streambuf, asio::transfer_exactly(content_length - num_additional_bytes), [this, session](const error_code &ec, std::size_t /*bytes_transferred*/) {
+              asio::async_read(*session->connection->socket, session->request->streambuf, asio::transfer_exactly((size_t)content_length - num_additional_bytes), [this, session](const error_code &ec, std::size_t /*bytes_transferred*/) {
                 session->connection->cancel_timeout();
                 auto lock = session->connection->handler_runner->continue_lock();
                 if(!lock)


### PR DESCRIPTION
`content_length` (`unsigned long long`) is bigger than `num_additional_bytes` (`size_t`) on Windows, so the compiler warns. Added a cast to make the compiler happy.