### PR TITLE
Include Port in Host

### DIFF
--- a/client_http.hpp
+++ b/client_http.hpp
@@ -425,7 +425,7 @@ namespace SimpleWeb {
       std::unique_ptr<asio::streambuf> streambuf(new asio::streambuf());
       std::ostream write_stream(streambuf.get());
       write_stream << method << " " << corrected_path << " HTTP/1.1\r\n";
-      write_stream << "Host: " << host << "\r\n";
+      write_stream << "Host: " << host << ":" << std::to_string(port) << "\r\n";
       for(auto &h : header)
         write_stream << h.first << ": " << h.second << "\r\n";
       return streambuf;


### PR DESCRIPTION
I had some trouble with sending requests on a new http server, appeared it checks for port in the "Host" Header and would give me 403 when not included.