### PR TITLE
Created non-templated base classes

### DIFF
--- a/client_https.hpp
+++ b/client_https.hpp
@@ -13,11 +13,11 @@ namespace SimpleWeb {
   using HTTPS = asio::ssl::stream<asio::ip::tcp::socket>;
 
   template <>
-  class Client<HTTPS> : public ClientBase<HTTPS> {
+  class Client<HTTPS> : public ClientTemplate<HTTPS> {
   public:
     Client(const std::string &server_port_path, bool verify_certificate = true, const std::string &cert_file = std::string(),
            const std::string &private_key_file = std::string(), const std::string &verify_file = std::string())
-        : ClientBase<HTTPS>::ClientBase(server_port_path, 443), context(asio::ssl::context::tlsv12) {
+        : ClientTemplate<HTTPS>::ClientTemplate(server_port_path, 443), context(asio::ssl::context::tlsv12) {
       if(cert_file.size() > 0 && private_key_file.size() > 0) {
         context.use_certificate_chain_file(cert_file);
         context.use_private_key_file(private_key_file, asio::ssl::context::pem);

--- a/server_https.hpp
+++ b/server_https.hpp
@@ -16,13 +16,13 @@ namespace SimpleWeb {
   using HTTPS = asio::ssl::stream<asio::ip::tcp::socket>;
 
   template <>
-  class Server<HTTPS> : public ServerBase<HTTPS> {
+  class Server<HTTPS> : public ServerTemplate<HTTPS> {
     std::string session_id_context;
     bool set_session_id_context = false;
 
   public:
     Server(const std::string &cert_file, const std::string &private_key_file, const std::string &verify_file = std::string())
-        : ServerBase<HTTPS>::ServerBase(443), context(asio::ssl::context::tlsv12) {
+        : ServerTemplate<HTTPS>::ServerTemplate(443), context(asio::ssl::context::tlsv12) {
       context.use_certificate_chain_file(cert_file);
       context.use_private_key_file(private_key_file, asio::ssl::context::pem);
 
@@ -63,10 +63,10 @@ namespace SimpleWeb {
         if(!ec) {
           asio::ip::tcp::no_delay option(true);
           error_code ec;
-          session->connection->socket->lowest_layer().set_option(option, ec);
+          connection->socket->lowest_layer().set_option(option, ec);
 
-          session->connection->set_timeout(config.timeout_request);
-          session->connection->socket->async_handshake(asio::ssl::stream_base::server, [this, session](const error_code &ec) {
+          connection->set_timeout(config.timeout_request);
+          connection->socket->async_handshake(asio::ssl::stream_base::server, [this, session](const error_code &ec) {
             session->connection->cancel_timeout();
             auto lock = session->connection->handler_runner->continue_lock();
             if(!lock)

--- a/tests/parse_test.cpp
+++ b/tests/parse_test.cpp
@@ -6,9 +6,9 @@
 using namespace std;
 using namespace SimpleWeb;
 
-class ServerTest : public ServerBase<HTTP> {
+class ServerTest : public ServerTemplate<HTTP> {
 public:
-  ServerTest() : ServerBase<HTTP>::ServerBase(8080) {}
+  ServerTest() : ServerTemplate<HTTP>::ServerTemplate(8080) {}
 
   void accept() noexcept override {}
 
@@ -51,9 +51,9 @@ public:
   }
 };
 
-class ClientTest : public ClientBase<HTTP> {
+class ClientTest : public ClientTemplate<HTTP> {
 public:
-  ClientTest(const std::string &server_port_path) : ClientBase<HTTP>::ClientBase(server_port_path, 80) {}
+  ClientTest(const std::string &server_port_path) : ClientTemplate<HTTP>::ClientTemplate(server_port_path, 80) {}
 
   std::shared_ptr<Connection> create_connection() noexcept override {
     return nullptr;


### PR DESCRIPTION
The base class is no longer a template class, making HTTP/HTTPS independent polymorphism on the client/server classes possible.

At first I didn't much like the idea due to added complexity, but now I'm pretty comfortable with the changes since the final solution is somewhat clean if not cleaner than before. Feedback is required though. 

Related to issue #168. See also discussion on PR #208. 

Example use:
```c++
#include "client_https.hpp"
#include "server_https.hpp"
#include <vector>

int main() {
  auto io_service = std::make_shared<SimpleWeb::asio::io_service>();
  std::vector<std::unique_ptr<SimpleWeb::ServerBase>> servers;

  servers.emplace_back(new SimpleWeb::Server<SimpleWeb::HTTP>());
  servers.back()->io_service = io_service;
  servers.back()->config.port = 8080;
  servers.back()->default_resource["GET"] = [](std::shared_ptr<SimpleWeb::Server<>::Response> response,
                                               std::shared_ptr<SimpleWeb::Server<>::Request> /*request*/) {
    response->write("Hello World");
  };

  servers.emplace_back(new SimpleWeb::Server<SimpleWeb::HTTPS>("server.crt", "server.key"));
  servers.back()->io_service = io_service;
  servers.back()->config.port = 8081;
  servers.back()->default_resource["GET"] = servers[0]->default_resource["GET"];

  for(auto &server : servers)
    server->start();

  io_service->run();
}
```