### PR TITLE
Support multiple calls to Response::send

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2014-2017 Ole Christian Eidheim
+Copyright (c) 2018 Caterpillar Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Currently, successive calls to `Response::send` may queue data to be sent twice. For example, the following will send "foo.foo.foo.bar.bar.baz.", when it should only send "foo.bar.baz.":

```c++
*response << "foo.";
response->send();
*response << "bar.";
response->send();
*response << "baz.";
response->send();
```

This pull request fixes the issue by taking a snapshot of the buffer before sending it. It also contains a unit test that fails with the old code but passes with the new. No other unit tests are broken by this code.